### PR TITLE
Fix bug with normalizing uri with a path of 1 char

### DIFF
--- a/src/main/java/org/codehaus/httpcache4j/uri/URIBuilder.java
+++ b/src/main/java/org/codehaus/httpcache4j/uri/URIBuilder.java
@@ -267,7 +267,7 @@ public final class URIBuilder {
             }
             builder.append(encodepath ? pathElement.getEncodedValue() : pathElement.getValue());
         }
-        if ((wasPathAbsolute || host.isPresent()) && builder.length() > 1) {
+        if ((wasPathAbsolute || host.isPresent()) && builder.length() > 0) {
             if (!"/".equals(builder.substring(0, 1))) {
                 builder.insert(0, "/");                
             }

--- a/src/test/java/org/codehaus/httpcache4j/uri/URIBuilderTest.java
+++ b/src/test/java/org/codehaus/httpcache4j/uri/URIBuilderTest.java
@@ -108,6 +108,13 @@ public class URIBuilderTest {
     }
 
     @Test
+    public void testNormalizedFromShortURI() {
+        String str = "http://www.example.com/a";
+        URI uri = URI.create(str);
+        assertEquals("URIs did not match", uri, URIBuilder.fromURI(uri).toNormalizedURI());
+    }
+
+    @Test
     public void testFromURIThenResetAndBuildWithQueryParameters() {
         URI uri = URI.create("http://www.example.com/a/path/here?foo=bar&bar=foo");
         URIBuilder builder = URIBuilder.fromURI(uri);


### PR DESCRIPTION
absoluteness isn't respected on normalize if the path is only 1 char
